### PR TITLE
'True' and 'False' integration phrase

### DIFF
--- a/docs/csharp/tutorials/intro-to-csharp/hello-world.yml
+++ b/docs/csharp/tutorials/intro-to-csharp/hello-world.yml
@@ -185,7 +185,7 @@ items:
 
     The <xref:System.String.Contains%2A> method returns a **boolean** value which tells you if the
     string you were searching for was found. A **boolean** stores either a `true` or a
-    `false` value. You'll learn more about **boolean** values
+    `false` value. When displayed as text output, they are capitalized: `True` and `False`, respectively. You'll learn more about **boolean** values
     in a later lesson.
 
     ***Challenge***


### PR DESCRIPTION
Should fix dotnet#17479 , up-for-grabs

## Summary

Followed this comment and added missing part:
https://github.com/dotnet/docs/issues/17479#issuecomment-600104324